### PR TITLE
MDEV-30418 : Setting wsrep_slave_threads causes thread hang

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-30418.result
+++ b/mysql-test/suite/galera/r/MDEV-30418.result
@@ -1,0 +1,41 @@
+connection node_2;
+connection node_1;
+connection node_1;
+connection node_2;
+connection node_2;
+select @@wsrep_slave_threads;
+@@wsrep_slave_threads
+1
+SET @cluster_address_orig = @@wsrep_cluster_address;
+SET GLOBAL wsrep_cluster_address=AUTO;
+SET GLOBAL wsrep_slave_threads=12;
+ERROR 42000: Variable 'wsrep_slave_threads' can't be set to the value of '12'
+SHOW WARNINGS;
+Level	Code	Message
+Warning	1231	Cannot set 'wsrep_slave_threads' because wsrep is disconnected
+Error	1231	Variable 'wsrep_slave_threads' can't be set to the value of '12'
+SET GLOBAL wsrep_cluster_address=ON;
+SET GLOBAL wsrep_slave_threads=0;
+ERROR 42000: Variable 'wsrep_slave_threads' can't be set to the value of '0'
+SHOW WARNINGS;
+Level	Code	Message
+Warning	1292	Truncated incorrect wsrep_slave_threads value: '0'
+Warning	1231	Cannot set 'wsrep_slave_threads' because wsrep is disconnected
+Error	1231	Variable 'wsrep_slave_threads' can't be set to the value of '0'
+SET GLOBAL wsrep_cluster_address='a';
+SET GLOBAL wsrep_slave_threads=2;
+ERROR 42000: Variable 'wsrep_slave_threads' can't be set to the value of '2'
+SHOW WARNINGS;
+Level	Code	Message
+Warning	1231	Cannot set 'wsrep_slave_threads' because wsrep is disconnected
+Error	1231	Variable 'wsrep_slave_threads' can't be set to the value of '2'
+select @@wsrep_slave_threads;
+@@wsrep_slave_threads
+1
+show status like 'wsrep_cluster_size';
+Variable_name	Value
+wsrep_cluster_size	2
+show status like 'wsrep_cluster_status';
+Variable_name	Value
+wsrep_cluster_status	Primary
+call mtr.add_suppression("WSREP:.*");

--- a/mysql-test/suite/galera/t/MDEV-30418.test
+++ b/mysql-test/suite/galera/t/MDEV-30418.test
@@ -1,0 +1,32 @@
+--source include/galera_cluster.inc
+
+# Save original auto_increment_offset values.
+--let $node_1=node_1
+--let $node_2=node_2
+--source ../galera/include/auto_increment_offset_save.inc
+
+--connection node_2
+select @@wsrep_slave_threads;
+SET @cluster_address_orig = @@wsrep_cluster_address;
+SET GLOBAL wsrep_cluster_address=AUTO;
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL wsrep_slave_threads=12;
+SHOW WARNINGS;
+SET GLOBAL wsrep_cluster_address=ON;
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL wsrep_slave_threads=0;
+SHOW WARNINGS;
+SET GLOBAL wsrep_cluster_address='a';
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL wsrep_slave_threads=2;
+SHOW WARNINGS;
+--disable_query_log
+SET GLOBAL wsrep_cluster_address = @cluster_address_orig;
+--enable_query_log
+select @@wsrep_slave_threads;
+show status like 'wsrep_cluster_size';
+show status like 'wsrep_cluster_status';
+call mtr.add_suppression("WSREP:.*");
+
+# Restore original auto_increment_offset values.
+--source ../galera/include/auto_increment_offset_restore.inc

--- a/mysql-test/suite/wsrep/r/wsrep_variables_wsrep_off.result
+++ b/mysql-test/suite/wsrep/r/wsrep_variables_wsrep_off.result
@@ -1,7 +1,6 @@
 SELECT @@wsrep_on;
 @@wsrep_on
 0
-SET @wsrep_slave_threads_global_saved = @@global.wsrep_slave_threads;
 SET @wsrep_debug_saved = @@global.wsrep_debug;
 SET SESSION wsrep_trx_fragment_size=DEFAULT;
 ERROR HY000: Incorrect arguments to SET
@@ -24,9 +23,10 @@ SELECT @@global.wsrep_debug;
 @@global.wsrep_debug
 NONE
 SET GLOBAL wsrep_slave_threads=5;
+ERROR HY000: WSREP (galera) not started
 SELECT @@global.wsrep_slave_threads;
 @@global.wsrep_slave_threads
-5
+1
 SET GLOBAL wsrep_desync=1;
 ERROR HY000: WSREP (galera) not started
 SELECT @@global.wsrep_desync;

--- a/mysql-test/suite/wsrep/t/wsrep_variables_wsrep_off.test
+++ b/mysql-test/suite/wsrep/t/wsrep_variables_wsrep_off.test
@@ -3,7 +3,6 @@
 
 SELECT @@wsrep_on;
 
-SET @wsrep_slave_threads_global_saved = @@global.wsrep_slave_threads;
 SET @wsrep_debug_saved = @@global.wsrep_debug;
 
 --error ER_WRONG_ARGUMENTS
@@ -15,6 +14,7 @@ SHOW WARNINGS;
 SELECT @@global.wsrep_start_position;
 SET GLOBAL wsrep_debug=1;
 SELECT @@global.wsrep_debug;
+--error ER_WRONG_ARGUMENTS
 SET GLOBAL wsrep_slave_threads=5;
 SELECT @@global.wsrep_slave_threads;
 --error ER_WRONG_ARGUMENTS
@@ -25,6 +25,5 @@ SET SESSION wsrep_trx_fragment_unit='rows';
 SELECT @@session.wsrep_trx_fragment_unit;
 
 --disable_query_log
-SET @@global.wsrep_slave_threads = @wsrep_slave_threads_global_saved;
 SET @@global.wsrep_debug = @wsrep_debug_saved;
 --enable_query_log

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -6080,7 +6080,7 @@ static Sys_var_ulong Sys_wsrep_slave_threads(
        GLOBAL_VAR(wsrep_slave_threads), CMD_LINE(REQUIRED_ARG),
        VALID_RANGE(1, 512), DEFAULT(1), BLOCK_SIZE(1),
        NO_MUTEX_GUARD, NOT_IN_BINLOG,
-       ON_CHECK(0),
+       ON_CHECK(wsrep_slave_threads_check),
        ON_UPDATE(wsrep_slave_threads_update));
 
 static Sys_var_charptr Sys_wsrep_dbug_option(

--- a/sql/wsrep_var.cc
+++ b/sql/wsrep_var.cc
@@ -1,4 +1,4 @@
-/* Copyright 2008-2023 Codership Oy <http://www.codership.com>
+/* Copyright 2008-2025 Codership Oy <http://www.codership.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -1174,6 +1174,29 @@ bool wsrep_forced_binlog_format_check(sys_var *self, THD* thd, set_var* var)
                  "if wsrep_mode=[REPLICATE_MYISAM|REPLICATE_ARIA]", MYF(0));
       return true;
     }
+  }
+
+  return false;
+}
+
+bool wsrep_slave_threads_check (sys_var *self, THD* thd, set_var* var)
+{
+  ulonglong new_slave_threads= var->save_result.ulonglong_value;
+
+  if (!WSREP_ON)
+  {
+    my_message(ER_WRONG_ARGUMENTS, "WSREP (galera) not started", MYF(0));
+    return true;
+  }
+
+  if (new_slave_threads &&
+      Wsrep_server_state::instance().state() == wsrep::server_state::s_disconnected)
+  {
+    push_warning(thd, Sql_condition::WARN_LEVEL_WARN,
+                 ER_WRONG_VALUE_FOR_VAR,
+                 "Cannot set 'wsrep_slave_threads' because "
+                 "wsrep is disconnected");
+    return true;
   }
 
   return false;


### PR DESCRIPTION
Problem was that wsrep was disconnected and new slave threads tried to connect to cluster but failed as
we were disconnected state.

Allow changing wsrep_slave_threads only when wsrep is enabled and we are connected to a cluster. In other cases report error and issue a warning.