### PR TITLE
MGL-60 Prioritize replicator and applier threads for CPU

### DIFF
--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -6281,6 +6281,14 @@ static Sys_var_charptr Sys_wsrep_patch_version(
        READ_ONLY GLOBAL_VAR(wsrep_patch_version_ptr), CMD_LINE_HELP_ONLY,
        DEFAULT(WSREP_PATCH_VERSION));
 
+static Sys_var_charptr Sys_wsrep_applier_priority(
+       "wsrep_applier_priority", "Scheduler and priority for WSREP applier threads",
+       PREALLOCATED GLOBAL_VAR(wsrep_applier_priority), CMD_LINE(OPT_ARG),
+       DEFAULT("other:0"),
+       NO_MUTEX_GUARD, NOT_IN_BINLOG,
+       ON_CHECK(wsrep_applier_priority_check),
+       ON_UPDATE(wsrep_applier_priority_update));
+
 #endif /* WITH_WSREP */
 
 static bool fix_host_cache_size(sys_var *, THD *, enum_var_type)

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -132,6 +132,8 @@ uint  wsrep_ignore_apply_errors= 0;
 
 std::atomic <bool> wsrep_thread_create_failed;
 
+const char *wsrep_applier_priority;             // Priority of applier threads!
+
 /*
  * End configuration options
  */
@@ -855,6 +857,8 @@ int wsrep_init()
   wsrep_init_position();
   wsrep_sst_auth_init();
 
+  thread_priority_manager = new Thread_priority_manager();
+
   if (!*wsrep_provider ||
       !strcasecmp(wsrep_provider, WSREP_NONE))
   {
@@ -1038,6 +1042,8 @@ void wsrep_deinit(bool free_options)
   {
     wsrep_sst_auth_free();
   }
+
+  delete thread_priority_manager;
 }
 
 /* Destroy wsrep thread LOCKs and CONDs */
@@ -3764,6 +3770,10 @@ void* start_wsrep_THD(void *arg)
 
   thd->real_id=pthread_self(); // Keep purify happy
 
+  // Allow the system variable "wsrep_applier_priority" to control
+  // the priority of this thread.
+  thread_priority_manager->add(thd->real_id);
+
   my_net_init(&thd->net,(st_vio*) 0, thd, MYF(0));
 
   DBUG_PRINT("wsrep",(("creating thread %lld"), (long long)thd->thread_id));
@@ -3834,6 +3844,8 @@ void* start_wsrep_THD(void *arg)
   /* Wsrep may reset globals during thread context switches, store globals
      before cleanup. */
   wsrep_store_threadvars(thd);
+
+  thread_priority_manager->remove(thd->real_id);
 
   close_connection(thd, 0);
 

--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -92,6 +92,7 @@ extern uint32      wsrep_gtid_domain_id;
 extern std::atomic <bool > wsrep_thread_create_failed;
 extern ulonglong   wsrep_mode;
 extern my_bool     wsrep_strict_ddl;
+extern const char *wsrep_applier_priority;
 
 enum enum_wsrep_reject_types {
   WSREP_REJECT_NONE,    /* nothing rejected */

--- a/sql/wsrep_var.h
+++ b/sql/wsrep_var.h
@@ -16,6 +16,7 @@
 #ifndef WSREP_VAR_H
 #define WSREP_VAR_H
 
+#include <set>
 #include <my_config.h>
 
 #ifdef WITH_WSREP
@@ -34,6 +35,123 @@
 class sys_var;
 class set_var;
 class THD;
+
+/*
+   Wrapper class for thread scheduling parameters. For details, about
+   values see sched_setscheduler(2) and pthread_setschedparams(3)
+   documentation.
+*/
+class Thread_sched_param
+{
+public:
+  /*
+     Default constructor. Initializes to default system
+     scheduling parameters.
+  */
+Thread_sched_param()
+    : policy_(SCHED_OTHER),
+      priority_(0)
+  { }
+
+  /*
+     Construct Thread_sched_param from given policy and priority
+     integer values.
+  */
+Thread_sched_param(int policy, int prio)
+    : policy_(policy),
+      priority_(prio)
+  { }
+
+  /*
+     Construct Thread_sched_param from given string representation
+      which must have form of
+
+        <policy>:<priority>
+
+     where policy is one of "other", "fifo", "rr" and priority
+     is an integer.
+  */
+  Thread_sched_param(const std::string& param);
+
+  /*
+     Set the policy and priority from the given string representation.
+
+     Return false if the call succeeds and true on failure.
+  */
+  bool set(const std::string& param);
+
+  // Return scheduling policy
+  int policy() const { return policy_; }
+
+  // Return scheduling priority
+  int priority() const { return priority_  ; }
+
+  // Equal to operator overload
+  bool operator==(const Thread_sched_param& other) const {
+    return (policy_ == other.policy_ && priority_ == other.priority_);
+  }
+
+  // Not equal to operator overload
+  bool operator!=(const Thread_sched_param& other) const {
+    return !(*this == other);
+  }
+
+  // Default system Thread_sched_param
+  static Thread_sched_param system_default;
+
+  void print(std::ostream& os) const;
+
+private:
+
+  int policy_;     // Scheduling policy
+  int priority_;   // Scheduling priority
+};
+
+
+/*
+  A manager of thread priorities for pthreads.
+
+  The manager keeps a list of threads (identified by pthread_t).
+  New threads can be added to the list with the add() method
+  and removed from the list by the remove() method.
+  The priorities of all the threads on the list are modified
+  with the update_priorities() call.
+ */
+class Thread_priority_manager
+{
+public:
+  Thread_priority_manager();
+  ~Thread_priority_manager();
+
+  void add(pthread_t thread);
+  void remove(pthread_t thread);
+  bool update_priorities(const char *priority_string);
+
+private:
+  /* list of threads */
+  std::set<pthread_t> m_threads;
+  /* current thread scheduling parameters */
+  Thread_sched_param m_sched_param;
+  /* for serializing all method calls */
+  mutable mysql_mutex_t LOCK_thread_priority_manager;
+
+  int set_priority(pthread_t thread);
+};
+
+/*
+   Return current scheduling parameters for given thread
+*/
+Thread_sched_param thread_get_schedparam(pthread_t thread);
+
+/*
+  Insertion operator for Thread_sched_param
+*/
+inline std::ostream& operator<<(std::ostream& os,
+                                const Thread_sched_param& sp)
+{
+  sp.print(os); return os;
+}
+
 
 int wsrep_init_vars();
 void wsrep_set_wsrep_on(THD *thd);
@@ -114,6 +232,12 @@ extern bool wsrep_strict_ddl_update          UPDATE_ARGS;
 extern bool wsrep_replicate_myisam_update    UPDATE_ARGS;
 extern bool wsrep_replicate_myisam_check     CHECK_ARGS;
 extern bool wsrep_forced_binlog_format_check CHECK_ARGS;
+
+extern bool wsrep_applier_priority_check     CHECK_ARGS;
+extern bool wsrep_applier_priority_update    UPDATE_ARGS;
+
+extern Thread_priority_manager *thread_priority_manager;
+
 #else  /* WITH_WSREP */
 
 #define wsrep_provider_init(X)


### PR DESCRIPTION
This patch adds a mechanism for setting the priority of WSREP applier and rollbacker threads via a new dynamic system variable "wsrep_applier_priority".

By default, the priority and scheduling policy are set to 0 and "other", respectively. This is encoded by the string "other:0" in the "wsrep_applier_priority" variable. The other scheduling policies are "rr" and "fifo". See sched(7) for details.